### PR TITLE
Read scrapyd url/port from scrapy.cfg

### DIFF
--- a/dynamic_scraper/utils/task_utils.py
+++ b/dynamic_scraper/utils/task_utils.py
@@ -23,17 +23,13 @@ class TaskUtils():
         }
         scrapyd_config = Config()
         try:
-            scrapyd_url = scrapyd_config.get('bind_address')
+            scrapyd_url = scrapyd_config.get('url')
         except NoOptionError:
-            scrapyd_url = "localhost"
-        try:
-            scrapyd_port = scrapyd_config.get('http_port')
-        except NoOptionError:
-            scrapyd_port = "6800"
+            scrapyd_url = "localhost:6800"
 
         params = urllib.urlencode(param_dict)
         headers = {"Content-type": "application/x-www-form-urlencoded", "Accept": "text/plain"}
-        conn = httplib.HTTPConnection(scrapyd_url + ":" + scrapyd_port)
+        conn = httplib.HTTPConnection(scrapyd_url)
         conn.request("POST", "/schedule.json", params, headers)
         conn.getresponse()
     


### PR DESCRIPTION
I am in a situation where I cannot run scrapy server on port 6800, so it would be nice to read http_port and bind_address values from scrapy.cfg and use these values instead of hardcoded localhost:6800. Address and port will default to localhost, 6800 if bind_address, http_port are not defined.
