### PR TITLE
fixed the exception when scheduler string was processed

### DIFF
--- a/dynamic_scraper/utils/scheduler.py
+++ b/dynamic_scraper/utils/scheduler.py
@@ -20,6 +20,7 @@ class Scheduler():
     def _parse_conf_dict_str(self, conf_dict_str):
         try:
             conf = conf_dict_str.strip(', ')
+            conf = conf.replace('\r\n','')
             conf = ast.literal_eval("{" + conf + "}")
         except SyntaxError:
             raise ImproperlyConfigured("Wrong context definition format: %s" % conf_dict_str)


### PR DESCRIPTION
the `ImproperlyConfigured` exception with " Wrong context definition format: "MIN_TIME": 15,... " error will be raised even the default scheduler setting was used, the reason is that the CRLF sometime isn't '\n' but '\r\n'
