### PR TITLE
Django 1.7 system check warning

### DIFF
--- a/dynamic_scraper/models.py
+++ b/dynamic_scraper/models.py
@@ -146,7 +146,7 @@ class ScraperElem(models.Model):
     scraper = models.ForeignKey(Scraper)   
     x_path = models.CharField(max_length=200)
     reg_exp = models.CharField(max_length=200, blank=True)
-    from_detail_page = models.BooleanField()
+    from_detail_page = models.BooleanField(default=False)
     processors = models.CharField(max_length=200, blank=True)
     proc_ctxt = models.CharField(max_length=200, blank=True)
     mandatory = models.BooleanField(default=True)


### PR DESCRIPTION
Silencing django 1.7 system check warning, setting the default value for from_detail_page to False. Fix #41 
